### PR TITLE
add return in ws

### DIFF
--- a/app/application/api/messages/websockets/messages.py
+++ b/app/application/api/messages/websockets/messages.py
@@ -32,6 +32,7 @@ async def websocket_endpoint(
         await websocket.accept()
         await websocket.send_json(data={'error': error.message})
         await websocket.close()
+        return
 
     await connection_manager.accept_connection(websocket=websocket, key=chat_oid)
 


### PR DESCRIPTION
Еще раз привет!

Небольшой фикс для вебсокета. Если не вызывать return - падает RuntimeError, так как после закрытия вебсокета ты пытаешься через connection_manager снова сделать accept этого соединения

Ошибка:
```
Traceback (most recent call last):
2024-07-16T17:02:20.640278510Z   File "/usr/local/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 240, in run_asgi
2024-07-16T17:02:20.640279885Z     result = await self.app(self.scope, self.asgi_receive, self.asgi_send)
2024-07-16T17:02:20.640280635Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-07-16T17:02:20.640281843Z   File "/usr/local/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 69, in __call__
2024-07-16T17:02:20.640282635Z     return await self.app(scope, receive, send)
2024-07-16T17:02:20.640283343Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-07-16T17:02:20.640283968Z   File "/usr/local/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
2024-07-16T17:02:20.640284718Z     await super().__call__(scope, receive, send)
2024-07-16T17:02:20.640285385Z   File "/usr/local/lib/python3.12/site-packages/starlette/applications.py", line 123, in __call__
2024-07-16T17:02:20.640286218Z     await self.middleware_stack(scope, receive, send)
2024-07-16T17:02:20.640286885Z   File "/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 151, in __call__
2024-07-16T17:02:20.640297218Z     await self.app(scope, receive, send)
2024-07-16T17:02:20.640297927Z   File "/usr/local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 65, in __call__
2024-07-16T17:02:20.640298718Z     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
2024-07-16T17:02:20.640299385Z   File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
2024-07-16T17:02:20.640300135Z     raise exc
2024-07-16T17:02:20.640300968Z   File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
2024-07-16T17:02:20.640301718Z     await app(scope, receive, sender)
2024-07-16T17:02:20.640302385Z   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 756, in __call__
2024-07-16T17:02:20.640303135Z     await self.middleware_stack(scope, receive, send)
2024-07-16T17:02:20.640303760Z   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 776, in app
2024-07-16T17:02:20.640304510Z     await route.handle(scope, receive, send)
2024-07-16T17:02:20.640305135Z   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 373, in handle
2024-07-16T17:02:20.640305885Z     await self.app(scope, receive, send)
2024-07-16T17:02:20.640306510Z   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 96, in app
2024-07-16T17:02:20.640307218Z     await wrap_app_handling_exceptions(app, session)(scope, receive, send)
2024-07-16T17:02:20.640309260Z   File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
2024-07-16T17:02:20.640310052Z     raise exc
2024-07-16T17:02:20.640310677Z   File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
2024-07-16T17:02:20.640311385Z     await app(scope, receive, sender)
2024-07-16T17:02:20.640312052Z   File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 94, in app
2024-07-16T17:02:20.640312760Z     await func(session)
2024-07-16T17:02:20.640313385Z   File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 348, in app
2024-07-16T17:02:20.640314135Z     await dependant.call(**values)
2024-07-16T17:02:20.640314760Z   File "/app/application/api/messages/websockets/messages.py", line 37, in websocket_endpoint
2024-07-16T17:02:20.640315510Z     await connection_manager.accept_connection(websocket=websocket, key=chat_oid)
2024-07-16T17:02:20.640316218Z   File "/app/infra/websockets/managers.py", line 44, in accept_connection
2024-07-16T17:02:20.640316927Z     await websocket.accept()
2024-07-16T17:02:20.640317593Z   File "/usr/local/lib/python3.12/site-packages/starlette/websockets.py", line 124, in accept
2024-07-16T17:02:20.640318302Z     await self.send(
2024-07-16T17:02:20.640318927Z   File "/usr/local/lib/python3.12/site-packages/starlette/websockets.py", line 112, in send
2024-07-16T17:02:20.640321135Z     raise RuntimeError('Cannot call "send" once a close message has been sent.')
2024-07-16T17:02:20.640321927Z RuntimeError: Cannot call "send" once a close message has been sent.
```